### PR TITLE
Don't crash with empty ICC file.

### DIFF
--- a/lib/colord/cd-icc.c
+++ b/lib/colord/cd-icc.c
@@ -1209,7 +1209,6 @@ cd_icc_load_data (CdIcc *icc,
 
 	g_return_val_if_fail (CD_IS_ICC (icc), FALSE);
 	g_return_val_if_fail (data != NULL, FALSE);
-	g_return_val_if_fail (data_len != 0, FALSE);
 	g_return_val_if_fail (priv->lcms_profile == NULL, FALSE);
 
 	/* ensure we have the header */


### PR DESCRIPTION
I couldn't find any documentation about how to submit colord patches, so here's a pull request.

Code already exists to handle corrupt files, but empty files caused an
assertion to fail instead.

Fixes: https://bugzilla.gnome.org/show_bug.cgi?id=709233

This should probably be backported to 1.0.x as well.
