### PR TITLE
Couple of fixes for running in a chroot or as root

### DIFF
--- a/lib/colord/cd-test-daemon.c
+++ b/lib/colord/cd-test-daemon.c
@@ -1652,7 +1652,7 @@ colord_device_async_func (void)
 	GError *error = NULL;
 	GHashTable *device_props;
 	const gchar *device_name = "device_async_dave";
-	gchar *device_path;
+	gchar *device_path, *device_path_nouid;
 	struct passwd *user_details;
 
 	/* no running colord to use */
@@ -1666,6 +1666,8 @@ colord_device_async_func (void)
 				      device_name,
 				      user_details->pw_name,
 				      user_details->pw_uid);
+	device_path_nouid = g_strdup_printf("/org/freedesktop/ColorManager/devices/%s",
+				            device_name);
 
 	client = cd_client_new ();
 
@@ -1700,9 +1702,16 @@ colord_device_async_func (void)
 
 	/* set a property in another instance */
 	device_tmp = cd_device_new_with_object_path (device_path);
-	ret = cd_device_connect_sync (device_tmp, NULL, &error);
-	g_assert_no_error (error);
-	g_assert (ret);
+	ret = cd_device_connect_sync (device_tmp, NULL, NULL);
+	if (!ret) {
+		g_object_unref (device_tmp);
+		g_free (device_path);
+		device_tmp = cd_device_new_with_object_path (device_path_nouid);
+		device_path = device_path_nouid;
+		ret = cd_device_connect_sync (device_tmp, NULL, &error);
+		g_assert_no_error (error);
+		g_assert (ret);
+	}
 	ret = cd_device_set_model_sync (device_tmp, "Cray", NULL, &error);
 	g_assert_no_error (error);
 	g_assert (ret);


### PR DESCRIPTION
I was trying to fix the colord tests in a chroot, as in Ubuntu we run them as automatic regression tests and they weren't passing.
- In a chroot we might not have a seat, so don't require this.
- polkit auth doesn't work in this environment, so I tried running as root. It then turns out that the device path doesn't include the uid or username, so fall back to trying this.

Also while running as root, I get the /colord/client{import} test failing with this message

/colord/client{import}: **
libcolord:ERROR:cd-test-daemon.c:1519:colord_client_import_func: assertion failed (error == NULL): The profile was not added in time (cd_client_error, 0)

haven't been able to figure out how to fix this one (it works in a real system).
