### PR TITLE
Fix session-helper failing to find argyll tool.

### DIFF
--- a/contrib/session-helper/cd-main.c
+++ b/contrib/session-helper/cd-main.c
@@ -939,7 +939,7 @@ cd_main_find_argyll_tool (const gchar *command,
 			  GError **error)
 {
 	gboolean ret;
-	_cleanup_free_ gchar *filename = NULL;
+	gchar *filename;
 
 	/* try the original argyllcms filename installed in /usr/local/bin */
 	filename = g_strdup_printf ("/usr/local/bin/%s", command);


### PR DESCRIPTION
We don't want to free the thing we're trying to return. This fixes the
bug introduced in commit b6f7c4d117a06f059a6e852e2dce8c13a3bb1f2c.

See:
  https://bugzilla.redhat.com/show_bug.cgi?id=1190720