### PR TITLE
cd_context_lcms_free(): do not leak GError**

### DIFF
--- a/lib/colord/cd-context-lcms.c
+++ b/lib/colord/cd-context-lcms.c
@@ -168,6 +168,7 @@ cd_context_lcms_free (gpointer ctx)
 
 	error_ctx = cmsGetContextUserData (ctx);
 	g_clear_error (error_ctx);
+	g_free (error_ctx);
 
 	cmsUnregisterPluginsTHR (ctx);
 	cmsDeleteContext (ctx);


### PR DESCRIPTION
I was working on fixing leaks in darktable, and found this.

I have installed colord with this change into /usr/local, and verified that this fixes the LeakSanitizer
complaint, makes *darktable-cmstest* leak-free and does not seem to cause any side-effects (at least so far).

We have manually allocated it in cd_context_lcms_new(), and
g_clear_error() does not free it, only it's content, if any.

Fixes following LeakSanitizer-detected leak:
Direct leak of 8 byte(s) in 1 object(s) allocated from:
    0 0x7f98f9924895 in calloc (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x54895)
    1 0x7f98f93af7f1 in g_malloc0 (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4f7f1)
    2 0x7f98f8306d19 in cd_context_lcms_new /home/lebedevri/src/colord/lib/colord/cd-context-lcms.c:154
    3 0x7f98f8314dd8 in cd_icc_init /home/lebedevri/src/colord/lib/colord/cd-icc.c:4012
    4 0x7f98f7d41f98 in g_type_create_instance (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x31f98)
    5 0x7f98f7d25866 (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x15866)
    6 0x7f98f7d2725c in g_object_newv (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x1725c)
    7 0x7f98f7d279f3 in g_object_new (/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x179f3)
    8 0x7f98f831ef90 in cd_icc_new /home/lebedevri/src/colord/lib/colord/cd-icc.c:4068
    9 0x7f98f85a0981 in cd_profile_load_icc (/usr/local/lib/libcolord.so.2+0x38981)
    10 0x4022c8 in main /home/lebedevri/darktable/src/cmstest/main.c:236
    11 0x7f98f7539b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    12 0x4018c8 (/usr/local/bin/darktable-cmstest+0x4018c8)