### PR TITLE
cd_client_connect_cb(): do not leak strings

### DIFF
--- a/lib/colord/cd-client.c
+++ b/lib/colord/cd-client.c
@@ -378,18 +378,26 @@ cd_client_connect_cb (GObject *source_object,
 	/* get daemon version */
 	daemon_version = g_dbus_proxy_get_cached_property (client->priv->proxy,
 							   CD_CLIENT_PROPERTY_DAEMON_VERSION);
-	if (daemon_version != NULL)
+	if (daemon_version != NULL) {
+		g_free (client->priv->daemon_version);
 		client->priv->daemon_version = g_variant_dup_string (daemon_version, NULL);
+	}
 
 	/* get system info */
 	system_vendor = g_dbus_proxy_get_cached_property (client->priv->proxy,
 							  CD_CLIENT_PROPERTY_SYSTEM_VENDOR);
-	if (system_vendor != NULL)
+	if (system_vendor != NULL) {
+		g_free (client->priv->system_vendor);
 		client->priv->system_vendor = g_variant_dup_string (system_vendor, NULL);
+	}
+
+	/* get system model */
 	system_model = g_dbus_proxy_get_cached_property (client->priv->proxy,
 							 CD_CLIENT_PROPERTY_SYSTEM_MODEL);
-	if (system_model != NULL)
+	if (system_model != NULL) {
+		g_free (client->priv->system_model);
 		client->priv->system_model = g_variant_dup_string (system_model, NULL);
+	}
 
 	/* get signals from DBus */
 	g_signal_connect (client->priv->proxy,


### PR DESCRIPTION
I was working on fixing leaks in darktable, and found this.

I have installed colord with this change into /usr/local, and verified that this fixes the LeakSanitizer complaint, makes darktable free of leaks in colord (or, at least i was not able to trigger others...) and does not seem to cause any side-effects (at least so far).

The reason is: client->priv is re-used several times, and cd_client_finalize()
is called only once at the end, so if cd_client_connect_cb() is called more
than once, it will re-duplicate those 3 strings, and the memory allocated
previously will leak.

Fixes several following LeakSanitizer-detected leaks like:
```
Direct leak of 23 byte(s) in 1 object(s) allocated from:
    0 0x7f647ff0474f in malloc (/usr/lib/x86_64-linux-gnu/libasan.so.1+0x5474f)
    1 0x7f647d29f799 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4f799)
    2 0x7f647d2b812e in g_strdup (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x6812e)

    3 0x7f6478cce792 in cd_client_connect_cb /home/lebedevri/src/colord/lib/colord/cd-client.c:382
or
    3 0x7f6478cce822 in cd_client_connect_cb /home/lebedevri/src/colord/lib/colord/cd-client.c:388
or
    3 0x7f6478cce8b9 in cd_client_connect_cb /home/lebedevri/src/colord/lib/colord/cd-client.c:392

    4 0x7f647d82cdf6 in g_simple_async_result_complete (/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0+0x74df6)
    5 0x7f647d82ce58 (/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0+0x74e58)
    6 0x7f647d299b4c in g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x49b4c)
    7 0x7f647d299f1f (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x49f1f)
    8 0x7f647d29a241 in g_main_loop_run (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x4a241)
    9 0x7f647f043bf4 in gtk_main (/usr/lib/x86_64-linux-gnu/libgtk-3.so.0+0x1ebbf4)
    10 0x7f647fa17eab in dt_gui_gtk_run /home/lebedevri/darktable/src/gui/gtk.c:964
    11 0x400cd3 in main /home/lebedevri/darktable/src/main.c:25
    12 0x7f6477ff9b44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    13 0x400bb8 (/usr/local/bin/darktable+0x400bb8)
```