### PR TITLE
session-helper: Replace '/' with '-' on the basename so creating the profile file doesn't fail.

### DIFF
--- a/contrib/session-helper/cd-main.c
+++ b/contrib/session-helper/cd-main.c
@@ -1563,6 +1563,7 @@ cd_main_set_basename (CdMainPrivate *priv)
 	GDateTime *datetime;
 	GString *str;
 	g_autofree gchar *date_str = NULL;
+	guint i;
 
 	str = g_string_new ("");
 
@@ -1597,6 +1598,11 @@ cd_main_set_basename (CdMainPrivate *priv)
 
 	/* remove trailing space */
 	g_string_set_size (str, str->len - 1);
+
+	/* Replace '/' with '-' on the string */
+	for (i = 0; i < str->len; i++)
+		if (str->str[i] == '/')
+			str->str[i] = '-';
 
 	/* make suitable filename */
 	g_strdelimit (str->str, "\"*?", '_');


### PR DESCRIPTION
I have a Samsung SyncMaster SA300 monitor; the model is referred as "Samsung SA300/SA350", which causes session-helper to set the basename to "Samsung SA300/SA350 (high) 2016-03-19 23-18-37 colorhug2", which of course fails because of the '/' in the filename.

My proposed patch is just the quick and dirty fix I came up with.