### PR TITLE
session-helper: Replace '/' with '-' on the basename so creating the profile file doesn't fail.

### DIFF
--- a/contrib/session-helper/cd-main.c
+++ b/contrib/session-helper/cd-main.c
@@ -1599,7 +1599,7 @@ cd_main_set_basename (CdMainPrivate *priv)
 	g_string_set_size (str, str->len - 1);
 
 	/* make suitable filename */
-	g_strdelimit (str->str, "\"*?", '_');
+	g_strdelimit (str->str, "/\"*?", '_');
 	priv->basename = g_string_free (str, FALSE);
 }
 


### PR DESCRIPTION
I have a Samsung SyncMaster SA300 monitor; the model is referred as "Samsung SA300/SA350", which causes session-helper to set the basename to "Samsung SA300/SA350 (high) 2016-03-19 23-18-37 colorhug2", which of course fails because of the '/' in the filename.
