### PR TITLE
Increase timeout to 60s for argyll spotread sampling

### DIFF
--- a/src/sensors/cd-sensor-argyll.c
+++ b/src/sensors/cd-sensor-argyll.c
@@ -31,7 +31,7 @@
 #include "cd-sensor.h"
 #include "cd-spawn.h"
 
-#define CD_SENSOR_ARGYLL_MAX_SAMPLE_TIME	10000 /* ms */
+#define CD_SENSOR_ARGYLL_MAX_SAMPLE_TIME	60000 /* ms */
 
 typedef enum {
 	CD_SENSOR_ARGYLL_POS_UNKNOWN,


### PR DESCRIPTION
There was a 10s timeout for spotread to finish sampling.  This works
fine for light colors, in which case it may finish in as little as 3
seconds.  But the darker the color is, the longer it takes to finish.
When measuring black, it takes around 25-30 seconds for my Spyder 3
Express.

The timeout caused Gnome Control Panel to fail when attempting to
calibrate.