### PR TITLE
Check polkit version before defining g_autoptr macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,10 @@ AM_CONDITIONAL(CD_BUILD_POLKIT, test x$enable_polkit = xyes)
 if test x$enable_polkit = xyes; then
 	PKG_CHECK_MODULES(POLKIT, polkit-gobject-1 >= 0.103)
 	AC_DEFINE(USE_POLKIT, 1, [if we should use PolicyKit])
+
+        PKG_CHECK_EXISTS([polkit-gobject-1 >= 0.114],
+                         [AC_DEFINE(POLKIT_HAS_AUTOPTR_MACROS, 1, [if PolKit has autoptr macros])],
+                         [])
 fi
 
 dnl ---------------------------------------------------------------------------

--- a/src/cd-common.c
+++ b/src/cd-common.c
@@ -29,12 +29,10 @@
 
 #include "cd-common.h"
 
-#ifdef USE_POLKIT
-#ifndef PolkitAuthorizationResult_autoptr
+#if defined(USE_POLKIT) && !defined(POLKIT_HAS_AUTOPTR_MACROS)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitSubject, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthority, g_object_unref)
-#endif
 #endif
 
 /**


### PR DESCRIPTION
We cannot check on the internal name created by G_DECLARE_AUTO* macros
because it's not a pre-processor symbol.

Instead, we should check whether we're being built against a version of
PolKit that has those symbols, and only define them ourselves for
previous versions.

This commit fixes a build failure in GNOME Continuous.