### PR TITLE
its: Make copyright translatable

### DIFF
--- a/data/profiles/its/colord.its
+++ b/data/profiles/its/colord.its
@@ -4,6 +4,7 @@
   <its:translateRule selector="//*" translate="no"/>
   <its:translateRule selector="//profile/name |
                                //profile/model |
-                               //profile/description"
+                               //profile/description |
+                               //profile/copyright"
                      translate="yes"/>
 </its:rules>


### PR DESCRIPTION
It was translatable before the move to gettext/Meson.