### PR TITLE
build: cd-self-test depends on generated resources

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -72,6 +72,7 @@ executable(
 if get_option('enable-tests')
   e = executable(
     'cd-self-test',
+    resources_src,
     sources : [
       'cd-common.c',
       'cd-device-array.c',


### PR DESCRIPTION
If we don't add the generated resource files as a source dependency,
Meson won't know that it has to build them first; this means that in
some cases, parallel builds will fail.