### PR TITLE
Conditional docs

### DIFF
--- a/configure
+++ b/configure
@@ -72,6 +72,7 @@ while (($# > 0)); do
 	--disable-bash-completion) enable_bash_completion='-Denable-bash-completion=false';;
 	--disable-argyllcms-sensor) enable_argyllcms_sensor='-Denable-argyllcms-sensor=false';;
 	--disable-installed-tests) enable_installed_tests='-Denable-installed-tests=false';;
+	--disable-man) enable_man='-Denable-man=false';;
 	*) echo -e "\e[1;33mINFO\e[0m: Ignoring unknown option '$1'";;
     esac
     shift
@@ -117,7 +118,7 @@ echo "  libdir:...... ${libdir}"
 echo "  mandir:...... ${mandir}"
 echo "  includedir:.. ${includedir}"
 echo "  additional:.."
-echo "    - ${enable_print_profiles} ${enable_argyllcms_sensor} ${enable_bash_completion} ${enable_installed_tests}"
+echo "    - ${enable_print_profiles} ${enable_argyllcms_sensor} ${enable_bash_completion} ${enable_installed_tests} ${enable_man}"
 
 exec ${MESON} \
 	--prefix=${prefix} \
@@ -133,6 +134,7 @@ exec ${MESON} \
 	${enable_argyllcms_sensor} \
 	${enable_bash_completion} \
 	${enable_installed_tests} \
+	${enable_man} \
 	${srcdir}
 
 # vim: ai ts=8 noet sts=2 ft=sh

--- a/configure
+++ b/configure
@@ -73,6 +73,7 @@ while (($# > 0)); do
 	--disable-argyllcms-sensor) enable_argyllcms_sensor='-Denable-argyllcms-sensor=false';;
 	--disable-installed-tests) enable_installed_tests='-Denable-installed-tests=false';;
 	--disable-man) enable_man='-Denable-man=false';;
+	--disable-gtk-doc) enable_docs='-Denable-docs=false';;
 	*) echo -e "\e[1;33mINFO\e[0m: Ignoring unknown option '$1'";;
     esac
     shift
@@ -118,7 +119,7 @@ echo "  libdir:...... ${libdir}"
 echo "  mandir:...... ${mandir}"
 echo "  includedir:.. ${includedir}"
 echo "  additional:.."
-echo "    - ${enable_print_profiles} ${enable_argyllcms_sensor} ${enable_bash_completion} ${enable_installed_tests} ${enable_man}"
+echo "    - ${enable_print_profiles} ${enable_argyllcms_sensor} ${enable_bash_completion} ${enable_installed_tests} ${enable_man} ${enable_docs}"
 
 exec ${MESON} \
 	--prefix=${prefix} \
@@ -135,6 +136,7 @@ exec ${MESON} \
 	${enable_bash_completion} \
 	${enable_installed_tests} \
 	${enable_man} \
+	${enable_docs} \
 	${srcdir}
 
 # vim: ai ts=8 noet sts=2 ft=sh

--- a/meson.build
+++ b/meson.build
@@ -236,7 +236,9 @@ subdir('po')
 # this needs libcolord
 subdir('client')
 subdir('contrib')
-subdir('doc')
+if get_option('enable-docs')
+  subdir('doc')
+endif
 
 # this needs client/cd-create-profile
 subdir('data')

--- a/meson.build
+++ b/meson.build
@@ -242,7 +242,9 @@ subdir('doc')
 subdir('data')
 
 # this needs data/profiles/*.icc
-subdir('man')
+if get_option('enable-man')
+  subdir('man')
+endif
 subdir('policy')
 subdir('rules')
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -9,3 +9,4 @@ option('enable-print-profiles', type : 'boolean', value : false, description : '
 option('enable-tests', type : 'boolean', value : true, description : 'Build self tests')
 option('enable-installed-tests', type : 'boolean', value : false, description : 'Install tests')
 option('with-daemon-user', type : 'string', value : 'root', description : 'User for running the colord daemon')
+option('enable-man', type : 'boolean', value : true, description : 'Generate man pages')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,3 +10,4 @@ option('enable-tests', type : 'boolean', value : true, description : 'Build self
 option('enable-installed-tests', type : 'boolean', value : false, description : 'Install tests')
 option('with-daemon-user', type : 'string', value : 'root', description : 'User for running the colord daemon')
 option('enable-man', type : 'boolean', value : true, description : 'Generate man pages')
+option('enable-docs', type : 'boolean', value : true, description : 'Generate documentation')


### PR DESCRIPTION
Build services like GNOME Continuous avoid building documentation, in order to skip the dependencies on docbook and other tools.