### PR TITLE
Replace the correct symbols in ch-version.h

### DIFF
--- a/lib/colorhug/meson.build
+++ b/lib/colorhug/meson.build
@@ -2,10 +2,15 @@ cargs = [
   '-DG_LOG_DOMAIN="libcolorhug"',
 ]
 
+ch_version_h_conf = configuration_data()
+ch_version_h_conf.set('CD_MAJOR_VERSION', colord_major_version)
+ch_version_h_conf.set('CD_MINOR_VERSION', colord_minor_version)
+ch_version_h_conf.set('CD_MICRO_VERSION', colord_micro_version)
+
 colorhug_version_h = configure_file(
   input : 'ch-version.h.in',
   output : 'ch-version.h',
-  configuration : conf,
+  configuration : ch_version_h_conf,
   install : true,
   install_dir: join_paths(get_option('includedir'), 'colord-1/colorhug'),
 )


### PR DESCRIPTION
When generating the ch-version.h header, we need to replace a set of
symbols at configuration time. The configuration_data object we are
using does not contain them.

Meson warns about this in newer versions:

    WARNING: The variable(s) 'CD_MAJOR_VERSION', 'CD_MICRO_VERSION',
    'CD_MINOR_VERSION' in the input file 'lib/colorhug/ch-version.h.in'
    are not present in the given configuration data

And the generated header is also invalid.