### PR TITLE
build: Enable C99 support in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,8 @@
 project('colord', 'c',
   version : '1.4.1',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.37.0'
+  meson_version : '>=0.37.0',
+  default_options : ['c_std=c99']
 )
 
 colord_version = meson.project_version()


### PR DESCRIPTION
We use C99 features (cd-spectrum.c:760), so need to explicitly enable them
in meson.build, as some compilers will not enable them automatically,
and will instead error when they encounter usage of C99.

Signed-off-by: Philip Withnall <withnall@endlessm.com>