### PR TITLE
Build fixes

### DIFF
--- a/lib/colord/cd-test-shared.c
+++ b/lib/colord/cd-test-shared.c
@@ -21,6 +21,10 @@
 
 #include "config.h"
 
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500
+#endif
+
 #include <limits.h>
 #include <stdlib.h>
 

--- a/lib/colord/cd-test-shared.c
+++ b/lib/colord/cd-test-shared.c
@@ -23,11 +23,14 @@
 
 #include <limits.h>
 #include <stdlib.h>
-#include <limits.h>
 
 #include <glib.h>
 
 #include "cd-test-shared.h"
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 gchar *
 cd_test_get_filename (const gchar *filename)


### PR DESCRIPTION
Colord fails to build in GNOME Continuous without these changes.

See full build log: http://build.gnome.org/continuous/buildmaster/builds/2017/08/12/18/build/log-colord.txt