### PR TITLE
build: Define _XOPEN_SOURCE in order to expose realpath() in headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -195,6 +195,9 @@ i18n = import('i18n')
 
 add_project_arguments('-DCD_COMPILATION', language: 'c')
 
+# Needed for realpath() and PATH_MAX
+add_project_arguments('-D_XOPEN_SOURCE=500', language : 'c')
+
 conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
 conf.set_quoted('BINDIR',
                 join_paths(get_option('prefix'),


### PR DESCRIPTION
We need realpath() (and PATH_MAX) for the tests, both of which need the
_XOPEN_SOURCE feature test macro. Define it.

Signed-off-by: Philip Withnall <withnall@endlessm.com>