### PR TITLE
colord: pass --pkg gio-2.0 when generating VAPI

### DIFF
--- a/lib/colord/meson.build
+++ b/lib/colord/meson.build
@@ -205,6 +205,7 @@ libcolord_typelib = libcolord_girtarget[1]
 if get_option('enable-vala')
 libfoo_vapi = gnome.generate_vapi('colord',
   sources: libcolord_girtarget[0],
+  packages: ['gio-2.0'],
   install: true,
 )
 endif


### PR DESCRIPTION
This prevents the parsing of Gio-2.0.gir, which would require additional
metadata to succeed.

Fixes #54