### PR TITLE
Enable reproducible builds

### DIFF
--- a/client/cd-it8.c
+++ b/client/cd-it8.c
@@ -35,6 +35,7 @@
 typedef struct {
 	GOptionContext		*context;
 	GPtrArray		*cmd_array;
+	gboolean		 timestamps;
 } CdUtilPrivate;
 
 typedef gboolean (*CdUtilPrivateCb)	(CdUtilPrivate	*util,
@@ -285,6 +286,7 @@ cd_util_create_cmf (CdUtilPrivate *priv,
 	if (dot != NULL)
 		*dot = '\0';
 	cd_it8_set_title (cmf, title);
+	cd_it8_set_enable_created (cmf, priv->timestamps);
 
 	/* save */
 	file = g_file_new_for_path (values[0]);
@@ -437,6 +439,7 @@ cd_util_create_sp (CdUtilPrivate *priv,
 	if (dot != NULL)
 		*dot = '\0';
 	cd_it8_set_title (cmf, title);
+	cd_it8_set_enable_created (cmf, priv->timestamps);
 
 	/* save */
 	file = g_file_new_for_path (values[0]);
@@ -455,6 +458,7 @@ main (int argc, char *argv[])
 	CdUtilPrivate *priv;
 	gboolean ret;
 	gboolean verbose = FALSE;
+	gboolean disable_timestamps = FALSE;
 	guint retval = 1;
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *cmd_descriptions = NULL;
@@ -462,6 +466,9 @@ main (int argc, char *argv[])
 		{ "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,
 			/* TRANSLATORS: command line option */
 			_("Show extra debugging information"), NULL },
+		{ "no-timestamps", 'd', 0, G_OPTION_ARG_NONE, &disable_timestamps,
+                        /* TRANSLATORS: command line option */
+                        _("Don't write embedded creation timestamps"), NULL },
 		{ NULL}
 	};
 
@@ -473,6 +480,7 @@ main (int argc, char *argv[])
 
 	/* create helper object */
 	priv = g_new0 (CdUtilPrivate, 1);
+	priv->timestamps = !disable_timestamps;
 
 	/* add commands */
 	priv->cmd_array = g_ptr_array_new_with_free_func ((GDestroyNotify) cd_util_item_free);

--- a/data/illuminant/meson.build
+++ b/data/illuminant/meson.build
@@ -20,11 +20,18 @@ generated_spectra = [
   'CIE-F8',
   'CIE-F9',
 ]
+
+generation_command = [ cd_idt8 ]
+if not get_option('enable-embedded-timestamps')
+  generation_command += '--no-timestamps'
+endif
+generation_command += [ 'create-sp', '@OUTPUT@', '@INPUT@', '100.0' ]
+
 foreach arg: generated_spectra
   custom_target(arg,
     input: arg + '.csv',
     output: arg + '.sp',
-    command: [ cd_idt8, 'create-sp', '@OUTPUT@', '@INPUT@', '100.0' ],
+    command: generation_command,
     install: true,
     install_dir: join_paths(datadir, 'colord', 'illuminant')
   )

--- a/lib/colord/cd-icc.h
+++ b/lib/colord/cd-icc.h
@@ -195,6 +195,8 @@ void		 cd_icc_remove_metadata			(CdIcc		*icc,
 GPtrArray	*cd_icc_get_named_colors		(CdIcc		*icc);
 gboolean	 cd_icc_get_can_delete			(CdIcc		*icc);
 GDateTime	*cd_icc_get_created			(CdIcc		*icc);
+void		 cd_icc_set_created			(CdIcc		*icc,
+							 GDateTime	*creation_time);
 const gchar	*cd_icc_get_checksum			(CdIcc		*icc);
 const gchar	*cd_icc_get_description			(CdIcc		*icc,
 							 const gchar	*locale,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,3 +12,4 @@ option('enable-installed-tests', type : 'boolean', value : false, description : 
 option('with-daemon-user', type : 'string', value : 'root', description : 'User for running the colord daemon')
 option('enable-man', type : 'boolean', value : true, description : 'Generate man pages')
 option('enable-docs', type : 'boolean', value : true, description : 'Generate documentation')
+option('enable-embedded-timestamps', type : 'boolean', value : true, description : 'Embed creation time stamp in it8 files')


### PR DESCRIPTION
There are two sources of non-reproducibility in the colord package build: creation timestamps in the generated ICC files, and timestamps in the cmf and sp files.

This disables creation timestamps in the cmf and sp files, and sets the ICC creation timestamps to either `SOURCE_DATE_EPOCH` or the creation time of the input file to `cd-create-profile`.

The ICC creation timestamp handling is somewhat awkward, but the LCMS2 maintainer is not interested in providing a more ergonomic way of setting the timestamp.