### PR TITLE
Make colord build on FreeBSD again

### DIFF
--- a/client/meson.build
+++ b/client/meson.build
@@ -114,3 +114,15 @@ cd_create_profile = executable(
   install : true,
   install_dir : bindir
 )
+
+run_cd_idt8 = [
+  join_paths(meson.source_root(), 'client', 'run.sh'),
+  join_paths(meson.build_root(), 'lib', 'colord'),
+  cd_idt8
+]
+
+run_cd_create_profile = [
+  join_paths(meson.source_root(), 'client', 'run.sh'),
+  join_paths(meson.build_root(), 'lib', 'colord'),
+  cd_create_profile
+]

--- a/client/run.sh
+++ b/client/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+library_path="$1"
+executable="$2"
+
+if [ "$LD_LIBRARY_PATH" ]; then
+    LD_LIBRARY_PATH="$library_path:$LD_LIBRARY_PATH"
+fi
+
+shift 2
+
+exec "$executable" "$@"

--- a/data/cmf/meson.build
+++ b/data/cmf/meson.build
@@ -2,7 +2,7 @@ foreach arg: [ 'CIE1964-10deg-XYZ', 'CIE1931-2deg-XYZ' ]
   custom_target(arg,
     input: arg + '.csv',
     output: arg + '.cmf',
-    command: [ cd_idt8, 'create-cmf', '@OUTPUT@', '@INPUT@', '1.0' ],
+    command: [ run_cd_idt8, 'create-cmf', '@OUTPUT@', '@INPUT@', '1.0' ],
     install: true,
     install_dir: join_paths(datadir, 'colord', 'cmf')
   )

--- a/data/illuminant/meson.build
+++ b/data/illuminant/meson.build
@@ -24,7 +24,7 @@ foreach arg: generated_spectra
   custom_target(arg,
     input: arg + '.csv',
     output: arg + '.sp',
-    command: [ cd_idt8, 'create-sp', '@OUTPUT@', '@INPUT@', '100.0' ],
+    command: [ run_cd_idt8, 'create-sp', '@OUTPUT@', '@INPUT@', '100.0' ],
     install: true,
     install_dir: join_paths(datadir, 'colord', 'illuminant')
   )

--- a/data/profiles/meson.build
+++ b/data/profiles/meson.build
@@ -59,7 +59,7 @@ foreach arg: icc_profiles
   generated_icc = custom_target(arg + '.icc',
     input: xml_i18n,
     output: arg + '.icc',
-    command: [ cd_create_profile, '--output=@OUTPUT@', '@INPUT@' ],
+    command: [ run_cd_create_profile, '--output=@OUTPUT@', '@INPUT@' ],
     install: true,
     install_dir: join_paths(datadir, 'color', 'icc', 'colord'),
   )


### PR DESCRIPTION
Unfortunately, colord is a hard dependency of gnome-control-center and gnome-settings-daemon, so I think we cannot make it hard-depend on a Linux-only project like udev. I also update the macro _XOPEN_SOURCE to 700 because 500 disables C99 features on FreeBSD.