### PR TITLE
build: Add data_dirs to po/meson.build

### DIFF
--- a/po/meson.build
+++ b/po/meson.build
@@ -2,5 +2,6 @@ i18n.gettext(meson.project_name(),
   preset : 'glib',
   args: [
   '--default-domain=' + meson.project_name(),
-  ]
+  ],
+  data_dirs: [join_paths(meson.source_root(), 'data/profiles')],
 )


### PR DESCRIPTION
Translation files in Transifex are lacking the color profile descriptions. It *could* be because of missing data_dirs in po/meson.build.