### PR TITLE
build: Fix linker argument checks

### DIFF
--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:28
 
 RUN dnf -y update
 RUN dnf -y install \

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('colord', 'c',
   version : '1.4.4',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.37.0',
+  meson_version : '>=0.46.0',
   default_options : ['c_std=c99']
 )
 
@@ -99,7 +99,7 @@ test_link_args = [
   '-Wl,-z,now',
 ]
 foreach arg: test_link_args
-  if cc.has_argument(arg)
+  if cc.has_link_argument(arg)
     global_link_args += arg
   endif
 endforeach


### PR DESCRIPTION
Meson 0.46.0 adds `has_link_argument` to compiler objects, and we should use it instead of `has_argument` when checking linker arguments.

Fixes: https://github.com/hughsie/colord/issues/69