### PR TITLE
Change our message to use the warning function

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -179,7 +179,7 @@ endif
 
 conf.set_quoted('DAEMON_USER', get_option('daemon_user'))
 if get_option('daemon_user') == 'root'
-  message('RUNNING THE DAEMON AS root IS NOT A GOOD IDEA, use -Ddaemon_user= to set user')
+  warning('RUNNING THE DAEMON AS root IS NOT A GOOD IDEA, use -Ddaemon_user= to set user')
 endif
 
 if get_option('pnp_ids') != ''


### PR DESCRIPTION
Since we now require meson 0.46, we can use this function
that was added in 0.44.