### PR TITLE
Tweaks to cd-sensor-argyll

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,7 +160,10 @@ if get_option('sane')
 endif
 
 if get_option('argyllcms_sensor')
-  spotread = find_program('spotread')
+  spotread = find_program('spotread', required : false)
+  if spotread.found() == false
+    warning('spotread not found. Argyll sensor will not work unless argyll is installed')
+  endif
   conf.set('HAVE_ARGYLLCMS_SENSOR', '1')
 endif
 

--- a/src/sensors/argyll/cd-sensor-argyll.c
+++ b/src/sensors/argyll/cd-sensor-argyll.c
@@ -251,7 +251,7 @@ cd_sensor_get_sample_async (CdSensor *sensor,
 	/* if spotread is not already running then execute */
 	if (!cd_spawn_is_running (priv->spawn)) {
 		argv = g_ptr_array_new_with_free_func (g_free);
-		g_ptr_array_add (argv, g_strdup ("/usr/bin/spotread"));
+		g_ptr_array_add (argv, g_strdup ("spotread"));
 		g_ptr_array_add (argv, g_strdup ("-d"));
 		g_ptr_array_add (argv, g_strdup_printf ("-c%u", priv->communication_port));
 		g_ptr_array_add (argv, g_strdup ("-N")); //no autocal


### PR DESCRIPTION
Previously with autotools I could manually override the `SPOTREAD` variable in package build to force it to be found. There doesn't seem to be an equivalent thing for meson, so spit out a warning if spotread is not found but allow the build to proceed.

Also it seems that cd-sensor-argyll sometimes spawns `spotread` and sometimes spawns `/usr/bin/spotread`; since the meson check is for `spotread` in `$PATH`, consistently use non-absolute paths.