### PR TITLE
lib/colord/meson.build: pass -DCD_COMPILATION to gir compiler

### DIFF
--- a/lib/colord/meson.build
+++ b/lib/colord/meson.build
@@ -186,6 +186,7 @@ libcolord_girtarget = gnome.generate_gir(colord,
   export_packages : 'colord',
   extra_args : [
     '--c-include=colord.h',
+    '-DCD_COMPILATION',
     ],
   link_with : colordprivate,
   dependencies : [

--- a/lib/colorhug/meson.build
+++ b/lib/colorhug/meson.build
@@ -101,6 +101,9 @@ libcolorhug_gir = gnome.generate_gir(colorhug,
     'GUsb-1.0',
     libcolord_gir,
   ],
+  extra_args : [
+    '-DCD_COMPILATION',
+  ],
   install : true
 )
 


### PR DESCRIPTION
Allows compilation when cross building, as Void Linux is doing so.

Other packages that also do it:

libgusb -> -DGUSB_COMPILATION
atk -> -DATK_COMPILATION
appstream-glib -> -DAS_COMPILATION