### PR TITLE
Fix owner & permissions on existing state files using tmpfiles.d snippet

### DIFF
--- a/data/colord.conf
+++ b/data/colord.conf
@@ -1,2 +1,0 @@
-d /var/lib/colord 0755 colord colord
-d /var/lib/colord/icc 0755 colord colord

--- a/data/colord.conf.in
+++ b/data/colord.conf.in
@@ -1,2 +1,3 @@
 d @localstatedir@/lib/colord 0755 @daemon_user@ @daemon_user@
 d @localstatedir@/lib/colord/icc 0755 @daemon_user@ @daemon_user@
+Z @localstatedir@/lib/colord 0755 @daemon_user@ @daemon_user@

--- a/data/colord.conf.in
+++ b/data/colord.conf.in
@@ -1,2 +1,2 @@
-d /var/lib/colord 0755 @daemon_user@ @daemon_user@
-d /var/lib/colord/icc 0755 @daemon_user@ @daemon_user@
+d @localstatedir@/lib/colord 0755 @daemon_user@ @daemon_user@
+d @localstatedir@/lib/colord/icc 0755 @daemon_user@ @daemon_user@

--- a/data/colord.conf.in
+++ b/data/colord.conf.in
@@ -1,0 +1,2 @@
+d /var/lib/colord 0755 @daemon_user@ @daemon_user@
+d /var/lib/colord/icc 0755 @daemon_user@ @daemon_user@

--- a/data/meson.build
+++ b/data/meson.build
@@ -13,10 +13,11 @@ if get_option('bash_completion')
 endif
 
 con2 = configuration_data()
+con2.set('localstatedir', localstatedir)
 con2.set('servicedir', libexecdir)
 con2.set('daemon_user', get_option('daemon_user'))
 
-# replace @servicedir@ and @daemon_user@
+# replace @servicedir@, @daemon_user@ and @localstatedir@
 if get_option('systemd')
   configure_file(
     input : 'colord.service.in',

--- a/data/meson.build
+++ b/data/meson.build
@@ -6,12 +6,6 @@ subdir('ref')
 subdir('tests')
 subdir('ti1')
 
-if get_option('systemd')
-  install_data('colord.conf',
-    install_dir: systemd.get_pkgconfig_variable('tmpfilesdir')
-  )
-endif
-
 if get_option('bash_completion')
   install_data('colormgr',
     install_dir: bash_completion.get_pkgconfig_variable('completionsdir')
@@ -30,6 +24,14 @@ if get_option('systemd')
     configuration : con2,
     install: true,
     install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
+  )
+
+  configure_file(
+    input : 'colord.conf.in',
+    output : 'colord.conf',
+    configuration : con2,
+    install: true,
+    install_dir: systemd.get_pkgconfig_variable('tmpfilesdir')
   )
 endif
 


### PR DESCRIPTION
On Endless, we previously configured colord to run as root, because otherwise it was not able to create /var/lib/colord. In the intervening years, a tmpfiles.d snippet was added to create that directory structure, so I now want to configure colord to run as colord.

However, on existing systems, files in the state directory are root-owned, so if I just configure it to run as colord it will be unable to write to its state files:

    colord[668]: CdDevice: failed to save mapping to database: SQL error: attempt to write a readonly database

It is a 1-line change to the tmpfiles.d file to make it fix permissions on existing files. To quote the commit message:

> 'd' creates a directory if missing, and fixes its permissions if it already
> exists, but it is not recursive. 'Z' recursively adjusts the permission of
> the given directory and its children, but only if it already exists.
> Together, these rules ensure that
> @localstatedir@/lib/colord and @localstatedir@/lib/colord/icc both exist,
> and that @localstatedir@/lib/colord and all its descendents are owned by
> the correct user.

As hinted at by that commit message, I also arranged for the file to have the configured username and state directory interpolated in at build time.

Although it's a harmless no-op on systems which were never configured in this way, I won't be at all offended if you prefer us to keep the `Z` line change (or indeed any of these patches) as a downstream change!