### PR TITLE
meson.build: update requirement to >=0.50.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('colord', 'c',
   version : '1.4.5',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.46.0',
+  meson_version : '>=0.50.0',
   default_options : ['c_std=c99']
 )
 


### PR DESCRIPTION
When building, the following message is displayed: `WARNING: Project targetting '>=0.46.0' but tried to use feature introduced in '0.50.0': install arg in configure_file`