### PR TITLE
trivial: Downgrade more trivial warning to a debug statement

### DIFF
--- a/src/cd-main.c
+++ b/src/cd-main.c
@@ -796,12 +796,12 @@ cd_main_get_cmdline_for_pid (guint pid)
 	proc_path = g_strdup_printf ("/proc/%u/cmdline", pid);
 	ret = g_file_get_contents (proc_path, &cmdline, &len, &error);
 	if (!ret) {
-		g_warning ("CdMain: failed to read %s: %s",
+		g_debug ("CdMain: failed to read %s: %s",
 			   proc_path, error->message);
 		return NULL;
 	}
 	if (len == 0) {
-		g_warning ("CdMain: failed to read %s", proc_path);
+		g_debug ("CdMain: failed to read %s", proc_path);
 		g_free (cmdline);
 		return NULL;
 	}


### PR DESCRIPTION
This is a follow up from https://github.com/hughsie/colord/commit/513bfa4783d0a630c226ee40638ab346c0d1c229 with a goal to avoid unnecessary spam in system logs. 
Fixes https://github.com/hughsie/colord/issues/48