### PR TITLE
libcolord: Add helpers for computing color adaptation matrices

### DIFF
--- a/lib/colord/cd-icc-utils.h
+++ b/lib/colord/cd-icc-utils.h
@@ -29,6 +29,7 @@
 #include <glib-object.h>
 
 #include "cd-icc.h"
+#include "cd-math.h"
 
 G_BEGIN_DECLS
 
@@ -36,6 +37,11 @@ gboolean	 cd_icc_utils_get_coverage		(CdIcc		*icc,
 							 CdIcc		*icc_reference,
 							 gdouble	*coverage,
 							 GError		**error);
+
+gboolean	cd_icc_utils_get_adaptation_matrix (CdIcc		*icc,
+						    CdIcc		*icc_reference,
+						    CdMat3x3		*out,
+						    GError		**error);
 
 G_END_DECLS
 

--- a/lib/colord/cd-icc.c
+++ b/lib/colord/cd-icc.c
@@ -3041,18 +3041,21 @@ cd_icc_get_white (CdIcc *icc)
 }
 
 /**
- * cd_icc_create_default:
+ * cd_icc_create_default_full:
  * @icc: A valid #CdIcc
- * @error: A #GError, or %NULL
+ * @flags: a set of #CdIccLoadFlags
+ * @error: (out): A #GError, or %NULL
  *
  * Creates a default sRGB ICC profile.
  *
  * Return value: %TRUE for success
  *
- * Since: 1.1.2
+ * Since: 1.4.5
  **/
 gboolean
-cd_icc_create_default (CdIcc *icc, GError **error)
+cd_icc_create_default_full (CdIcc *icc,
+			    CdIccLoadFlags flags,
+			    GError **error)
 {
 	CdIccPrivate *priv = GET_PRIVATE (icc);
 	gboolean ret = TRUE;
@@ -3079,7 +3082,7 @@ cd_icc_create_default (CdIcc *icc, GError **error)
 	}
 
 	/* get defaults from profile */
-	ret = cd_icc_load (icc, 0, error);
+	ret = cd_icc_load (icc, flags, error);
 	if (!ret)
 		goto out;
 
@@ -3092,6 +3095,23 @@ cd_icc_create_default (CdIcc *icc, GError **error)
 			     cd_standard_space_to_string (CD_STANDARD_SPACE_SRGB));
 out:
 	return ret;
+}
+
+/**
+ * cd_icc_create_default:
+ * @icc: A valid #CdIcc
+ * @error: (out): A #GError, or %NULL
+ *
+ * Creates a default sRGB ICC profile.
+ *
+ * Return value: %TRUE for success
+ *
+ * Since: 1.1.2
+ **/
+gboolean
+cd_icc_create_default (CdIcc *icc, GError **error)
+{
+	return cd_icc_create_default_full (icc, CD_ICC_LOAD_FLAGS_NONE, error);
 }
 
 /**

--- a/lib/colord/cd-icc.h
+++ b/lib/colord/cd-icc.h
@@ -255,6 +255,10 @@ gboolean	 cd_icc_create_from_edid_data		(CdIcc		*icc,
 gboolean	 cd_icc_create_default			(CdIcc		*icc,
 							 GError		**error)
 							 G_GNUC_WARN_UNUSED_RESULT;
+gboolean	 cd_icc_create_default_full		(CdIcc		*icc,
+							 CdIccLoadFlags	 flags,
+							 GError		**error)
+							 G_GNUC_WARN_UNUSED_RESULT;
 GPtrArray	*cd_icc_get_vcgt			(CdIcc		*icc,
 							 guint		 size,
 							 GError		**error)

--- a/lib/colord/cd-it8-utils.c
+++ b/lib/colord/cd-it8-utils.c
@@ -183,10 +183,8 @@ cd_it8_utils_calculate_ccmx (CdIt8 *it8_reference,
 	CdMat3x3 m_rgb;
 	CdMat3x3 m_rgb_inv;
 	CdMat3x3 n_rgb;
-	const gdouble *data;
 	gdouble m_lumi = 0.0f;
 	gdouble n_lumi = 0.0f;
-	guint i;
 	g_autofree gchar *tmp = NULL;
 
 	/* read reference matrix */
@@ -217,14 +215,8 @@ cd_it8_utils_calculate_ccmx (CdIt8 *it8_reference,
 	g_debug ("device calibration = %s", tmp);
 
 	/* check there are no nan's or inf's */
-	data = cd_mat33_get_data (&calibration);
-	for (i = 0; i < 9; i++) {
-		if (fpclassify (data[i]) != FP_NORMAL) {
-			g_set_error (error, 1, 0,
-				     "Matrix value %u non-normal: %f", i, data[i]);
-			return FALSE;
-		}
-	}
+	if (!cd_mat33_is_finite (&calibration, error))
+		return FALSE;
 
 	/* save to ccmx file */
 	cd_it8_set_matrix (it8_ccmx, &calibration);

--- a/lib/colord/cd-math.c
+++ b/lib/colord/cd-math.c
@@ -453,3 +453,30 @@ cd_mat33_copy (const CdMat3x3 *src, CdMat3x3 *dest)
 	g_return_if_fail (src != dest);
 	memcpy (dest, src, sizeof (CdMat3x3));
 }
+
+/**
+ * cd_mat33_is_finite:
+ * @mat: the matrix to test
+ * @error: (out): A #GError, or %NULL
+ *
+ * Determine whether all entries in the specified matrix are finite and not
+ * NaNs.
+ *
+ * Return value: %TRUE if isfinite() returns %TRUE for all values.
+ */
+gboolean
+cd_mat33_is_finite (const CdMat3x3 *mat, GError **error)
+{
+	const gdouble *data = cd_mat33_get_data (mat);
+
+	for (guint i = 0; i < 9; i++) {
+		if (!isfinite (data[i])) {
+			g_set_error (error, 1, 0,
+				     "Matrix value %u non-normal: %f",
+				     i, data[i]);
+			return FALSE;
+		}
+	}
+
+	return TRUE;
+}

--- a/lib/colord/cd-math.h
+++ b/lib/colord/cd-math.h
@@ -88,6 +88,8 @@ void		 cd_mat33_normalize		(const CdMat3x3		*src,
 						 CdMat3x3		*dest);
 void		 cd_mat33_copy			(const CdMat3x3		*src,
 						 CdMat3x3		*dest);
+gboolean	 cd_mat33_is_finite		(const CdMat3x3		*mat,
+						 GError			**error);
 
 #undef __CD_MATH_H_INSIDE__
 


### PR DESCRIPTION
Modern computer display hardware supports having a 3x3 (or 3x4, in some cases) color transformation matrix between the degamma and regamma lookup tables. Currently, these matrices are not used by desktop environments and instead, the desktop environment chooses a single ICC profile to present to applications, and some applications use that to apply their own correction matrix.

Downsides to this approach are that only the profile for a single "primary" monitor is available to applications, and only some color-aware applications actually make use of these profiles. Using the hardware matrix allows the appropriate correction to be applied on a per-monitor basis, and for it to be applied automatically by the window system rather than requiring per-application support.

In order to use this matrix hardware, the desktop environment needs to be able to compute a correction matrix given each display's measured ICC profile and a reference profile, typically sRGB. This series adds functions that can be used for this purpose.

Related merge requests for plumbing this behavior through GNOME and the X.Org modesetting driver to the kernel interface for the color transformation matrix:
- https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/159
- https://gitlab.gnome.org/GNOME/gnome-desktop/merge_requests/62
- https://gitlab.gnome.org/GNOME/mutter/merge_requests/1048
- https://gitlab.freedesktop.org/xorg/xserver/merge_requests/352