### PR TITLE
Handle mangled mapping.db

### DIFF
--- a/src/cd-mapping-db.c
+++ b/src/cd-mapping-db.c
@@ -91,9 +91,17 @@ cd_mapping_db_load (CdMappingDb *mdb,
 	}
 
 	/* we don't need to keep doing fsync */
-	sqlite3_exec (priv->db, "PRAGMA synchronous=OFF",
-		      NULL, NULL, NULL);
-
+	rc = sqlite3_exec (priv->db, "PRAGMA synchronous=OFF",
+		      NULL, NULL, &error_msg);
+	if (rc != SQLITE_OK) {
+			g_set_error (error,
+				     CD_CLIENT_ERROR,
+				     CD_CLIENT_ERROR_INTERNAL,
+				     "Failed to turn off synchronous operations: SQL error: %s",
+				     error_msg);
+			sqlite3_free (error_msg);
+			return FALSE;
+	}
 	/* check mappings */
 	rc = sqlite3_exec (priv->db, "SELECT * FROM mappings LIMIT 1",
 			   NULL, NULL, &error_msg);


### PR DESCRIPTION
If mapping.db is corrupted somehow then colord won't start up.  Detect this case and attempt to delete the file and try again.

Closes #111.