### PR TITLE
fix cd_icc_load_data() annotation for the data array

### DIFF
--- a/lib/colord/cd-icc.c
+++ b/lib/colord/cd-icc.c
@@ -1153,7 +1153,7 @@ cd_icc_load (CdIcc *icc, CdIccLoadFlags flags, GError **error)
 /**
  * cd_icc_load_data:
  * @icc: a #CdIcc instance.
- * @data: binary data
+ * @data: (array length=data_len): binary data
  * @data_len: Length of @data
  * @flags: a set of #CdIccLoadFlags
  * @error: A #GError or %NULL


### PR DESCRIPTION
`data` is an array, but without the correct annotation it is treated as a single (binary data) value by GObject introspection.

With this fix, e.g. Python code like this works:
```
# get a copy of the ICC profile with MD5 checksum calculated
icc_data = icc.save_data(Colord.IccSaveFlags.NONE)
icc2 = Colord.Icc()
icc2.load_data(icc_data.get_data(), Colord.IccLoadFlags.FALLBACK_MD5)
```
(Yes, that code is a workaround in itself... :wink:)

Thanks to Chris Williams from the GNOME `#python` IRC channel for pointing out the annotations being wrong.