### PR TITLE
tests: Don't use exact floating point comparisons.

### DIFF
--- a/lib/colord/cd-test-private.c
+++ b/lib/colord/cd-test-private.c
@@ -1494,7 +1494,7 @@ colord_icc_func (void)
 	/* check profile properties */
 	g_assert_cmpint (cd_icc_get_size (icc), ==, 25244);
 	g_assert_cmpstr (cd_icc_get_checksum (icc), ==, "9ace8cce8baac8d492a93a2a232d7702");
-	g_assert_cmpfloat (cd_icc_get_version (icc), ==, 3.4);
+	g_assert_cmpfloat_with_epsilon (cd_icc_get_version (icc), 3.4, 0.01);
 	g_assert (g_str_has_suffix (cd_icc_get_filename (icc), "ibm-t61.icc"));
 	g_assert_cmpint (cd_icc_get_kind (icc), ==, CD_PROFILE_KIND_DISPLAY_DEVICE);
 	g_assert_cmpint (cd_icc_get_colorspace (icc), ==, CD_COLORSPACE_RGB);
@@ -1727,7 +1727,7 @@ colord_icc_save_func (void)
 	g_object_unref (file);
 
 	/* verify changed values */
-	g_assert_cmpfloat (cd_icc_get_version (icc), ==, 2.09);
+	g_assert_cmpfloat_with_epsilon (cd_icc_get_version (icc), 2.09, 0.001);
 	g_assert_cmpint (cd_icc_get_kind (icc), ==, CD_PROFILE_KIND_OUTPUT_DEVICE);
 	g_assert_cmpint (cd_icc_get_colorspace (icc), ==, CD_COLORSPACE_XYZ);
 	g_assert_cmpstr (cd_icc_get_metadata_item (icc, "SelfTest"), ==, "true");

--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,7 @@ add_global_link_arguments(
 )
 
 gio = dependency('gio-2.0', version : '>= 2.45.8')
-glib = dependency('glib-2.0')
+glib = dependency('glib-2.0', version : '>= 2.58')
 gmodule = dependency('gmodule-2.0')
 giounix = dependency('gio-unix-2.0', version : '>= 2.45.8')
 lcms = dependency('lcms2', version : '>= 2.6')


### PR DESCRIPTION
On some platforms (at least i386, armel, and s390x) the `cd_icc_get_version` tests fail, as the floating point values are not *exactly* equivalent.