### PR TITLE
libcolord: Add missing copyright notices

### DIFF
--- a/lib/colord/cd-icc-utils.c
+++ b/lib/colord/cd-icc-utils.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2013 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2020 NVIDIA CORPORATION
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
  *

--- a/lib/colord/cd-icc-utils.h
+++ b/lib/colord/cd-icc-utils.h
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2013 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2020 NVIDIA CORPORATION
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
  *

--- a/lib/colord/cd-icc.c
+++ b/lib/colord/cd-icc.c
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2013 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2020 NVIDIA CORPORATION
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
  *

--- a/lib/colord/cd-icc.h
+++ b/lib/colord/cd-icc.h
@@ -1,6 +1,7 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
  * Copyright (C) 2013 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2020 NVIDIA CORPORATION
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
  *


### PR DESCRIPTION
I forgot to add copyright notices for commits 9aba3df and 6d64e4c.