### PR TITLE
Fix the potential memory leak of sqlite3_exec()

### DIFF
--- a/src/cd-device-db.c
+++ b/src/cd-device-db.c
@@ -79,7 +79,7 @@ cd_device_db_load (CdDeviceDb *ddb,
 
 	/* check devices */
 	rc = sqlite3_exec (priv->db, "SELECT * FROM devices LIMIT 1",
-			   NULL, NULL, &error_msg);
+			   NULL, NULL, NULL);
 	if (rc != SQLITE_OK) {
 		g_debug ("CdDeviceDb: creating table to repair: %s", error_msg);
 		sqlite3_free (error_msg);
@@ -91,7 +91,7 @@ cd_device_db_load (CdDeviceDb *ddb,
 
 	/* check properties version 2 */
 	rc = sqlite3_exec (priv->db, "SELECT * FROM properties_v2 LIMIT 1",
-			   NULL, NULL, &error_msg);
+			   NULL, NULL, NULL);
 	if (rc != SQLITE_OK) {
 		statement = "CREATE TABLE properties_v2 ("
 			    "device_id TEXT,"

--- a/src/cd-device-db.c
+++ b/src/cd-device-db.c
@@ -79,7 +79,7 @@ cd_device_db_load (CdDeviceDb *ddb,
 
 	/* check devices */
 	rc = sqlite3_exec (priv->db, "SELECT * FROM devices LIMIT 1",
-			   NULL, NULL, NULL);
+			   NULL, NULL, &error_msg);
 	if (rc != SQLITE_OK) {
 		g_debug ("CdDeviceDb: creating table to repair: %s", error_msg);
 		sqlite3_free (error_msg);


### PR DESCRIPTION
This PR fixes the issue https://github.com/hughsie/colord/issues/110 by setting the 5th parameter of `sqlite3_exec()` to NULL.
