### PR TITLE
Drop references to hughski.com

### DIFF
--- a/contrib/session-helper/org.freedesktop.ColorHelper.gschema.xml
+++ b/contrib/session-helper/org.freedesktop.ColorHelper.gschema.xml
@@ -27,13 +27,5 @@
         introduce latency.
       </description>
     </key>
-    <key name="profile-upload-uri" type="s">
-      <default>'http://www.hughski.com/profile-store.php'</default>
-      <summary>Web service profile upload URI</summary>
-      <description>
-        The URI of the web service that allows the calibration tools to upload a
-        specific profile to the Internet.
-      </description>
-    </key>
   </schema>
 </schemalist>

--- a/doc/website/faq.html
+++ b/doc/website/faq.html
@@ -222,7 +222,7 @@ take readings:
 </p>
 <ul>
 <li><a href="http://www.pantone.co.uk/pages/products/product.aspx?pid=562">Pantone Huey</a></li>
-<li><a href="http://www.hughski.com/">Hughski ColorHug</a></li>
+<li>Hughski ColorHug (<a href="https://blogs.gnome.org/hughsie/2018/02/01/no-new-batches-of-colorhug2/">no longer produced</a>)</li>
 <li><a href="http://www.xrite.com/product_overview.aspx?Action=support&ID=730">XRite DTP94</a></li>
 </ul>
 </p>


### PR DESCRIPTION
The domain has been abandoned and taken over by spammers.

Color profile upload was never implemented in colord.

The ColorHug family of products is no longer produced:

https://blogs.gnome.org/hughsie/2018/02/01/no-new-batches-of-colorhug2/