### PR TITLE
build: drop intltool remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Ensure the following packages are installed:
 * glib2-devel
 * gobject-introspection-devel
 * gtk-doc
-* intltool
 * lcms2-devel
 * libgudev1-devel
 * libgusb-devel

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,6 +1,5 @@
 *.gmo
 *.header
-.intltool-merge-cache
 Makefile.in.in
 Makevars.template
 POTFILES

--- a/po/.gitignore
+++ b/po/.gitignore
@@ -1,9 +1,7 @@
 *.gmo
 *.header
-Makefile.in.in
 Makevars.template
 POTFILES
 Rules-quot
 *.sed
 *.sin
-stamp-it


### PR DESCRIPTION
Dependency was dropped in the port to Meson (158fba0).

Signed-off-by: Sam James <sam@gentoo.org>Dependency was dropped in the port to Meson (158fba0).

Signed-off-by: Sam James <sam@gentoo.org>