### PR TITLE
lib: avoid destructing LCMS plugin twice with lcms 2.14

### DIFF
--- a/lib/colord/cd-context-lcms.c
+++ b/lib/colord/cd-context-lcms.c
@@ -163,7 +163,6 @@ cd_context_lcms_free (gpointer ctx)
 	g_clear_error (error_ctx);
 	g_free (error_ctx);
 
-	cmsUnregisterPluginsTHR (ctx);
 	cmsDeleteContext (ctx);
 }
 


### PR DESCRIPTION
lcms 2.14 contains a change to avoid a memory leak, but that change assumes correct API usage. It's not necessary to both cmsUnregisterPluginsTHR() and then cmsDeleteContext() -- we can just straight up delete the LCMS context instead (cmsDeleteContext()).

So, follow upstream's suggestion & do that. This fixes memory corruption when building colord on x86, for example.

Bug: https://github.com/mm2/Little-CMS/issues/344
Fixes: https://github.com/hughsie/colord/issues/145
Signed-off-by: Sam James <sam@gentoo.org>