### PR TITLE
lib: pass a correct tag size to cmsReadRawTag

### DIFF
--- a/lib/colord/cd-icc.c
+++ b/lib/colord/cd-icc.c
@@ -372,6 +372,7 @@ cd_icc_to_string (CdIcc *icc)
 	g_string_append (str, "\n");
 	number_tags = cmsGetTagCount (priv->lcms_profile);
 	for (i = 0; i < number_tags; i++) {
+		gchar *buf = NULL;
 		sig = cmsGetTagSignature (priv->lcms_profile, i);
 
 		/* convert to text */
@@ -397,7 +398,11 @@ cd_icc_to_string (CdIcc *icc)
 			continue;
 		}
 		g_string_append_printf (str, "  size\t%i\n", tag_size);
-		cmsReadRawTag (priv->lcms_profile, sig, &tmp, 4);
+
+		buf = g_malloc (tag_size);
+		cmsReadRawTag (priv->lcms_profile, sig, buf, tag_size);
+		memcpy (tag_str, buf, tag_size < 4 ? tag_size : 4);
+		g_free (buf);
 
 		cd_icc_uint32_to_str (tmp, tag_str);
 		tag_type = GUINT32_FROM_BE (tmp);


### PR DESCRIPTION
Since lcms-2.14, the cmsReadRawTag will not fill the buffer if the buffer size is smaller than expected [1].  It causes cd-iccdump to segfault, and the test colord-test-private to fail.

Allocate a buffer with correct size and pass it to cmsReadRawTag to fix the issue.

Fixes #147.

[1]: https://github.com/mm2/Little-CMS/commit/3d3001f0118984570a162d0b239d739529920e12