### PR TITLE
lib/icc: Always close profile when loading fails

### DIFF
--- a/lib/colord/cd-icc.c
+++ b/lib/colord/cd-icc.c
@@ -2099,6 +2099,7 @@ cd_icc_load_handle (CdIcc *icc,
 	/* check the THR version has been correctly set up */
 	context = cmsGetProfileContextID (handle);
 	if (context == NULL) {
+		cmsCloseProfile (handle);
 		g_set_error_literal (error,
 				     CD_ICC_ERROR,
 				     CD_ICC_ERROR_FAILED_TO_CREATE,


### PR DESCRIPTION
cd_icc_load() always takes ownership of the passed profile, but will leak it if the initial condition fails and the funtion returns an error. Only if the actual profile loading fails, will the passed profile eventually not be leaked. Fix this by closing it immediately in the first case.

----

This might not be a good solution, but the API doesn't allow  the caller to close the profile after calling the load function, so we need something to not leak here. The alternative is to *always* set the internal pointer to have it closed on finalization; that would avoid any user-after-free if the caller makes the assumption that the profiles is still valid (which might not be that far fetched since the API mentions it's kept around until finalize).

Another alternative is to treat it as a programming error to not have context ID (but I guess still set an error), and still leak in that case.