### PR TITLE
add various hardenings to the systemd service

### DIFF
--- a/data/colord.service.in
+++ b/data/colord.service.in
@@ -6,7 +6,29 @@ Type=dbus
 BusName=org.freedesktop.ColorManager
 ExecStart=@servicedir@/colord
 User=@daemon_user@
-# We think that udev's AF_NETLINK messages are being filtered when
-# network namespacing is on.
-# PrivateNetwork=yes
 PrivateTmp=yes
+ProtectSystem=strict
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictRealtime=true
+RestrictAddressFamilies=AF_UNIX
+
+# drop all capabilities
+CapabilityBoundingSet=~CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER CAP_NET_ADMIN CAP_SYS_RAWIO CAP_SYS_TIME CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE CAP_KILL CAP_MKNOD CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SYS_NICE CAP_SYS_RESOURCE CAP_MAC_ADMIN CAP_MAC_OVERRIDE CAP_SYS_BOOT CAP_LINUX_IMMUTABLE CAP_IPC_LOCK CAP_SYS_CHROOT CAP_BLOCK_SUSPEND CAP_LEASE CAP_SYS_PACCT CAP_SYS_TTY_CONFIG CAP_WAKE_ALARM
+
+NoNewPrivileges=true
+PrivateUsers=true
+ProtectProc=invisible
+ProcSubset=pid
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
+
+RestrictNamespaces=~cgroup user pid net uts mnt ipc
+
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RemoveIPC=true


### PR DESCRIPTION
I don't have the proper hardware to test this. The first eight settings have been active in openSUSE for a while without ill effect. For the others I also don't expect fallout, but that needs some testing I unfortunately can't provide