### PR TITLE
data: don't make state files executable in tmpfiles.d/colord.conf

### DIFF
--- a/data/colord.conf.in
+++ b/data/colord.conf.in
@@ -1,3 +1,3 @@
 d @localstatedir@/lib/colord 0755 @daemon_user@ @daemon_user@
 d @localstatedir@/lib/colord/icc 0755 @daemon_user@ @daemon_user@
-Z @localstatedir@/lib/colord 0755 @daemon_user@ @daemon_user@
+Z @localstatedir@/lib/colord - @daemon_user@ @daemon_user@


### PR DESCRIPTION
Specifying the 0755 mode for the 'Z' directive applies not only to directories but also to files, making them executable. Instead, omit the mode so that directories and files are given the default 0755 and 0644 modes, respectively.

Fixes: rhbz#2249302