### PR TITLE
Use thread context for Gamut Alarm codes.

### DIFF
--- a/lib/colord/cd-icc-utils.c
+++ b/lib/colord/cd-icc-utils.c
@@ -95,7 +95,7 @@ cd_icc_utils_get_coverage_calc (CdIcc *icc,
 	/* set gamut alarm to 0xffff */
 	alarm_codes = g_new0 (cmsUInt16Number, cmsMAXCHANNELS);
 	alarm_codes[0] = 0xffff;
-	cmsSetAlarmCodes (alarm_codes);
+	cmsSetAlarmCodesTHR(cd_icc_get_context (icc), alarm_codes);
 
 	/* slice profile in regular intervals */
 	data = g_new0 (cmsFloat32Number, data_len * 3);


### PR DESCRIPTION
When making a proofing transform, we place it in it's own context. Then when setting an alarm code later, we should use the same context to ensure our intended alarm code is set in the right context.