### PR TITLE
Fix USB scanners not working with RestrictAddressFamilies

### DIFF
--- a/data/colord.service.in
+++ b/data/colord.service.in
@@ -15,7 +15,6 @@ ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true
 RestrictRealtime=true
-RestrictAddressFamilies=AF_UNIX
 
 ConfigurationDirectory=colord
 StateDirectory=colord


### PR DESCRIPTION
colord-sane scanner drivers using libusb can't initialize properly with RestrictAddressFamilies set to AF_UNIX. Remove that line to ensure those can work properly.

This also avoids a crash in HPLIP due to unchecked calls to libusb_init().

Fixes #165