### PR TITLE
fix NULL passed to free with sqlite3 error_msg pointers

### DIFF
--- a/src/cd-device-db.c
+++ b/src/cd-device-db.c
@@ -48,7 +48,7 @@ cd_device_db_load (CdDeviceDb *ddb,
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
 	const gchar *statement;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 	g_autofree gchar *path = NULL;
 
@@ -109,7 +109,7 @@ cd_device_db_empty (CdDeviceDb *ddb,
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
 	const gchar *statement;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 
 	g_return_val_if_fail (CD_IS_DEVICE_DB (ddb), FALSE);
@@ -137,7 +137,7 @@ cd_device_db_add (CdDeviceDb *ddb,
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 
@@ -175,7 +175,7 @@ cd_device_db_set_property (CdDeviceDb *ddb,
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 
@@ -212,7 +212,7 @@ cd_device_db_remove (CdDeviceDb *ddb,
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement1 = NULL;
 	gchar *statement2 = NULL;
 	gint rc;
@@ -277,7 +277,7 @@ cd_device_db_get_property (CdDeviceDb *ddb,
 			   GError  **error)
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	gchar *value = NULL;
@@ -331,7 +331,7 @@ cd_device_db_get_devices (CdDeviceDb *ddb,
 			  GError  **error)
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	GPtrArray *array = NULL;
@@ -372,7 +372,7 @@ cd_device_db_get_properties (CdDeviceDb *ddb,
 			     GError  **error)
 {
 	CdDeviceDbPrivate *priv = GET_PRIVATE (ddb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	GPtrArray *array = NULL;

--- a/src/cd-mapping-db.c
+++ b/src/cd-mapping-db.c
@@ -67,7 +67,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
 		    GError  **error)
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 	g_autofree gchar *path = NULL;
 
@@ -131,7 +131,7 @@ cd_mapping_db_load (CdMappingDb *mdb,
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
 	const gchar *statement;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 	g_autofree gchar *path = NULL;
 
@@ -230,7 +230,7 @@ cd_mapping_db_empty (CdMappingDb *mdb,
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
 	const gchar *statement;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 
 	g_return_val_if_fail (CD_IS_MAPPING_DB (mdb), FALSE);
@@ -259,7 +259,7 @@ cd_mapping_db_add (CdMappingDb *mdb,
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	gint64 timestamp;
@@ -307,7 +307,7 @@ cd_mapping_db_clear_timestamp (CdMappingDb *mdb,
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 
@@ -351,7 +351,7 @@ cd_mapping_db_remove (CdMappingDb *mdb,
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 
@@ -406,7 +406,7 @@ cd_mapping_db_get_profiles (CdMappingDb *mdb,
 			    GError  **error)
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	GPtrArray *array = NULL;
@@ -456,7 +456,7 @@ cd_mapping_db_get_devices (CdMappingDb *mdb,
 			   GError  **error)
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	GPtrArray *array = NULL;
@@ -522,7 +522,7 @@ cd_mapping_db_get_timestamp (CdMappingDb *mdb,
 			     GError  **error)
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 	guint64 timestamp = G_MAXUINT64;

--- a/src/cd-mapping-db.c
+++ b/src/cd-mapping-db.c
@@ -67,7 +67,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
 		    GError  **error)
 {
 	CdMappingDbPrivate *priv = GET_PRIVATE (mdb);
-	g_autofree gchar *error_msg = NULL;
+	gchar *error_msg = NULL;
 	gint rc;
 	g_autofree gchar *path = NULL;
 
@@ -97,6 +97,7 @@ cd_mapping_db_open (CdMappingDb *mdb,
 	if (rc != SQLITE_OK) {
 		/* Database appears to be mangled, so wipe it and try again */
 		sqlite3_close (priv->db);
+		sqlite3_free(error_msg);
 		priv->db = NULL;
 
 		if (retry) {

--- a/src/cd-profile-db.c
+++ b/src/cd-profile-db.c
@@ -48,7 +48,7 @@ cd_profile_db_load (CdProfileDb *pdb,
 {
 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
 	const gchar *statement;
-	g_autofree gchar *error_msg = NULL;
+	gchar *error_msg = NULL;
 	gint rc;
 	g_autofree gchar *path = NULL;
 
@@ -69,6 +69,7 @@ cd_profile_db_load (CdProfileDb *pdb,
 			     CD_CLIENT_ERROR_INTERNAL,
 			     "Can't open database: %s\n",
 			     sqlite3_errmsg (priv->db));
+		sqlite3_free (error_msg);
 		sqlite3_close (priv->db);
 		return FALSE;
 	}

--- a/src/cd-profile-db.c
+++ b/src/cd-profile-db.c
@@ -48,7 +48,7 @@ cd_profile_db_load (CdProfileDb *pdb,
 {
 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
 	const gchar *statement;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 	g_autofree gchar *path = NULL;
 
@@ -98,7 +98,7 @@ cd_profile_db_empty (CdProfileDb *pdb, GError **error)
 {
 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
 	const gchar *statement;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gint rc;
 
 	g_return_val_if_fail (CD_IS_PROFILE_DB (pdb), FALSE);
@@ -129,7 +129,7 @@ cd_profile_db_set_property (CdProfileDb *pdb,
 {
 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 
@@ -169,7 +169,7 @@ cd_profile_db_remove (CdProfileDb *pdb,
 {
 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement = NULL;
 	gint rc;
 
@@ -223,7 +223,7 @@ cd_profile_db_get_property (CdProfileDb *pdb,
 {
 	CdProfileDbPrivate *priv = GET_PRIVATE (pdb);
 	gboolean ret = TRUE;
-	gchar *error_msg = NULL;
+	char *error_msg = NULL;
 	gchar *statement;
 	gint rc;
 


### PR DESCRIPTION
when an error does not happen, and an error_msg pointer is passed,
sqlite does not touch it. that means this pointer is uninitialised
(=NULL) which violates the constraints of g_autofree ("the variable must
be initialized").

this is then passed to g_free and crashes in tests.

use a regular pointer and free it manually on error, after sqlite writes
to it after setting it with sqlite_malloc.

fixes https://github.com/hughsie/colord/issues/163  

---

of note `cd_profile_db_empty` and every other place with sqlite error handling was already doing this