### PR TITLE
man: Add the source attribute for each man page

### DIFF
--- a/man/cd-create-profile.xml
+++ b/man/cd-create-profile.xml
@@ -14,6 +14,7 @@
   <refmeta>
     <refentrytitle>cd-create-profile</refentrytitle>
     <manvolnum>1</manvolnum>
+    <refmiscinfo class="source">colord</refmiscinfo>
     <refmiscinfo class="manual">User Commands</refmiscinfo>
   </refmeta>
   <refnamediv>

--- a/man/cd-fix-profile.xml
+++ b/man/cd-fix-profile.xml
@@ -14,6 +14,7 @@
   <refmeta>
     <refentrytitle>cd-fix-profile</refentrytitle>
     <manvolnum>1</manvolnum>
+    <refmiscinfo class="source">colord</refmiscinfo>
     <refmiscinfo class="manual">User Commands</refmiscinfo>
   </refmeta>
   <refnamediv>

--- a/man/cd-it8.xml
+++ b/man/cd-it8.xml
@@ -14,6 +14,7 @@
   <refmeta>
     <refentrytitle>cd-it8</refentrytitle>
     <manvolnum>1</manvolnum>
+    <refmiscinfo class="source">colord</refmiscinfo>
     <refmiscinfo class="manual">User Commands</refmiscinfo>
   </refmeta>
   <refnamediv>

--- a/man/colormgr.xml
+++ b/man/colormgr.xml
@@ -14,6 +14,7 @@
   <refmeta>
     <refentrytitle>colormgr</refentrytitle>
     <manvolnum>1</manvolnum>
+    <refmiscinfo class="source">colord</refmiscinfo>
     <refmiscinfo class="manual">User Commands</refmiscinfo>
   </refmeta>
   <refnamediv>


### PR DESCRIPTION
Without it, the man page contains "FIXME: source" at the left-bottom corner.