### PR TITLE
Allow building with elogind

### DIFF
--- a/contrib/session-helper/meson.build
+++ b/contrib/session-helper/meson.build
@@ -13,7 +13,7 @@ con2 = configuration_data()
 con2.set('servicedir', libexecdir)
 
 # replace @servicedir@
-if get_option('systemd')
+if get_option('systemd') and systemd.found()
   configure_file(
     input : 'colord-session.service.in',
     output : 'colord-session.service',

--- a/data/meson.build
+++ b/data/meson.build
@@ -18,7 +18,7 @@ con2.set('servicedir', libexecdir)
 con2.set('daemon_user', get_option('daemon_user'))
 
 # replace @servicedir@, @daemon_user@ and @localstatedir@
-if get_option('systemd')
+if get_option('systemd') and systemd.found()
   configure_file(
     input : 'colord.service.in',
     output : 'colord.service',

--- a/meson.build
+++ b/meson.build
@@ -127,7 +127,7 @@ if get_option('udev_rules')
 endif
 
 if get_option('systemd')
-  systemd = dependency('systemd')
+  systemd = dependency('systemd', required : false)
   libsystemd = dependency('libsystemd')
   conf.set('HAVE_SYSTEMD', '1')
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,7 +26,7 @@ resources_src = gnome.compile_resources(
 )
 
 colord_extra_deps = []
-if get_option('systemd')
+if get_option('systemd') and libsystemd.found()
   colord_extra_deps += libsystemd
 endif
 


### PR DESCRIPTION
This makes the runtime systemd dep requirement optional when building with -Dsystemd=true so that colord can be built with support for libsystemd on distros that use elogind. There should be no impact here when building colord on distros that use systemd, both libsystemd and systemd should exist in that case.