### PR TITLE
Drop component type from AppStream metadata XML to avoid parsing error.

### DIFF
--- a/org.freedesktop.colord.metainfo.xml
+++ b/org.freedesktop.colord.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component>
   <id>org.freedesktop.colord</id>
   <metadata_license>MIT</metadata_license>
   <name>colord</name>


### PR DESCRIPTION
I just discovered that the AppStream parser in Debian find an error in the AppStream metadata XML I introduced in commit 259f5cbf28e917841a888af219b5fbfd1a7692ad.  Due to a cut-n-paste error on my part, the component uses type="desktop", which should only be used by packages with a XDG .desktop file.