### PR TITLE
Install sysusers.d config file if configured user is not root

### DIFF
--- a/data/colord.sysusers.conf.in
+++ b/data/colord.sysusers.conf.in
@@ -1,0 +1,1 @@
+u @daemon_user@ - "colord colour management daemon" @localstatedir@/lib/colord

--- a/data/meson.build
+++ b/data/meson.build
@@ -34,6 +34,16 @@ if get_option('systemd')
     install: true,
     install_dir: systemd.get_pkgconfig_variable('tmpfilesdir')
   )
+
+  if get_option('daemon_user') != 'root'
+    configure_file(
+      input : 'colord.sysusers.conf.in',
+      output : 'colord.conf',
+      configuration : con2,
+      install: true,
+      install_dir: systemd.get_pkgconfig_variable('sysusersdir')
+    )
+  endif
 endif
 
 # replace @servicedir@ and @daemon_user@


### PR DESCRIPTION
Given both the unit and the tmpfiles.d use the user configured at build time, also ship a sysusers.d so that it can be created on first boot on image-based deployments.