### PR TITLE
Argyll: Send SIGTERM instead of SIGQUIT to the Argyll processes

### DIFF
--- a/contrib/session-helper/cd-main.c
+++ b/contrib/session-helper/cd-main.c
@@ -796,6 +796,10 @@ static gboolean
 cd_main_finished_quit_cb (gpointer user_data)
 {
 	CdMainPrivate *priv = (CdMainPrivate *) user_data;
+	if (priv->sensor)
+		cd_sensor_unlock_sync(priv->sensor, NULL, NULL);
+	if (priv->device)
+		cd_device_profiling_uninhibit_sync(priv->device, NULL, NULL);
 	g_main_loop_quit (priv->loop);
 	return G_SOURCE_REMOVE;
 }
@@ -1499,6 +1503,10 @@ static gboolean
 cd_main_quit_loop_cb (gpointer user_data)
 {
 	CdMainPrivate *priv = (CdMainPrivate *) user_data;
+	if (priv->sensor)
+		cd_sensor_unlock_sync(priv->sensor, NULL, NULL);
+	if (priv->device)
+		cd_device_profiling_uninhibit_sync(priv->device, NULL, NULL);
 	g_main_loop_quit (priv->loop);
 	return G_SOURCE_REMOVE;
 }

--- a/src/sensors/argyll/cd-sensor-argyll.c
+++ b/src/sensors/argyll/cd-sensor-argyll.c
@@ -418,11 +418,11 @@ cd_sensor_unlock_exit_cb (CdSpawn *spawn,
 			  CdSpawnExitType exit_type,
 			  GTask *task)
 {
-	if (exit_type != CD_SPAWN_EXIT_TYPE_SIGQUIT) {
+	if (exit_type != CD_SPAWN_EXIT_TYPE_SIGTERM) {
 		g_task_return_new_error (task,
 					 CD_SENSOR_ERROR,
 					 CD_SENSOR_ERROR_INTERNAL,
-					 "exited without sigquit");
+					 "exited without sigterm");
 		g_object_unref (task);
 		return;
 	}

--- a/src/sensors/argyll/cd-spawn.h
+++ b/src/sensors/argyll/cd-spawn.h
@@ -56,7 +56,7 @@ typedef struct
 typedef enum {
 	CD_SPAWN_EXIT_TYPE_SUCCESS,		/* script run, without any problems */
 	CD_SPAWN_EXIT_TYPE_FAILED,		/* script failed to run */
-	CD_SPAWN_EXIT_TYPE_SIGQUIT,		/* we killed the instance (SIGQUIT) */
+	CD_SPAWN_EXIT_TYPE_SIGTERM,		/* we killed the instance (SIGTERM) */
 	CD_SPAWN_EXIT_TYPE_SIGKILL,		/* we killed the instance (SIGKILL) */
 	CD_SPAWN_EXIT_TYPE_UNKNOWN
 } CdSpawnExitType;


### PR DESCRIPTION
Sending SIGQUIT causes them to generate a coredump

Fixes: https://github.com/hughsie/colord/issues/189